### PR TITLE
Add Flask app with streaming chat

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "app.main:app"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,13 @@
+from flask import Flask
+
+from .routes import chat_bp
+from .services.chatbot import OpenAIChatBot
+
+
+def create_app(chatbot: OpenAIChatBot | None = None) -> Flask:
+    app = Flask(__name__)
+    if chatbot is None:
+        chatbot = OpenAIChatBot()
+    app.config["CHATBOT"] = chatbot
+    app.register_blueprint(chat_bp)
+    return app

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -1,0 +1,30 @@
+from functools import wraps
+from flask import request, jsonify
+
+
+def validate(model):
+    """Validate incoming JSON data against a Pydantic model."""
+
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            try:
+                data = model(**request.get_json(force=True))
+            except Exception as exc:  # pragma: no cover - simple example
+                return jsonify({"error": str(exc)}), 400
+            return await func(data, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def log_call(func):
+    """Log function calls."""
+
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        print(f"Calling {func.__name__}")
+        return await func(*args, **kwargs)
+
+    return wrapper

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,6 @@
+from . import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,8 @@
+flask>=2.3
+httpx>=0.25
+langchain>=0.1
+langchain-community>=0.0.21
+openai>=1.0
+pydantic>=2.0
+pytest-asyncio>=0.23
+gunicorn>=21

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, Response, current_app
+
+from .decorators import log_call, validate
+from .schema import ChatInput
+
+chat_bp = Blueprint("chat", __name__)
+
+
+@chat_bp.route("/chat", methods=["POST"])
+@log_call
+@validate(ChatInput)
+async def chat_endpoint(data: ChatInput) -> Response:
+    async def generate() -> str:
+        async for token in current_app.config["CHATBOT"].stream_chat(data.message):
+            yield token
+
+    return Response(generate(), mimetype="text/plain")

--- a/app/schema.py
+++ b/app/schema.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, constr
+
+
+class ChatInput(BaseModel):
+    """Schema for chat requests."""
+
+    message: constr(min_length=1, strip_whitespace=True)

--- a/app/services/chatbot.py
+++ b/app/services/chatbot.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncGenerator
+
+import httpx
+from langchain_community.chat_models import ChatOpenAI
+from langchain.schema import HumanMessage
+
+
+class ChatBotBase:
+    """Base chatbot with streaming and HTTP helpers."""
+
+    def __init__(
+        self,
+        model_name: str,
+        temperature: float = 0.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.model_name = model_name
+        self.temperature = temperature
+        self.client = client or httpx.AsyncClient()
+
+    async def stream_chat(self, message: str) -> AsyncGenerator[str, None]:
+        raise NotImplementedError
+
+    async def fetch_status(self, url: str) -> int:
+        """Fetch a URL using httpx to demonstrate async HTTP calls."""
+        response = await self.client.get(url)
+        return response.status_code
+
+    async def aclose(self) -> None:
+        await self.client.aclose()
+
+    def __repr__(self) -> str:  # pragma: no cover - simple dunder method
+        return f"{self.__class__.__name__}(model_name={self.model_name!r})"
+
+
+class OpenAIChatBot(ChatBotBase):
+    """Chatbot using OpenAI via LangChain."""
+
+    def __init__(
+        self,
+        model_name: str = "gpt-3.5-turbo",
+        temperature: float = 0.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(model_name, temperature, client)
+        self.llm = ChatOpenAI(
+            model_name=model_name,
+            temperature=temperature,
+            streaming=True,
+        )
+
+    async def stream_chat(self, message: str) -> AsyncGenerator[str, None]:
+        async for chunk in self.llm.astream([HumanMessage(content=message)]):
+            yield chunk.content or ""
+
+
+class DummyChatBot(ChatBotBase):
+    """Simplified bot for tests."""
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        super().__init__("dummy", client=client)
+
+    async def stream_chat(self, message: str) -> AsyncGenerator[str, None]:
+        for word in message.split():
+            yield word
+            await asyncio.sleep(0)

--- a/app/tests/test_chatbot.py
+++ b/app/tests/test_chatbot.py
@@ -1,0 +1,34 @@
+import pytest
+import httpx
+
+from pydantic import ValidationError
+
+from app.schema import ChatInput
+from app.services.chatbot import DummyChatBot
+
+
+def test_chat_input_validation():
+    data = ChatInput(message="hello")
+    assert data.message == "hello"
+
+    with pytest.raises(ValidationError):
+        ChatInput(message="")
+
+
+@pytest.mark.asyncio
+async def test_dummy_chatbot_stream():
+    bot = DummyChatBot()
+    tokens = [token async for token in bot.stream_chat("foo bar")]
+    assert tokens == ["foo", "bar"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_status():
+    async def handler(request: httpx.Request) -> httpx.Response:  # type: ignore
+        return httpx.Response(200)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        bot = DummyChatBot(client=client)
+        status = await bot.fetch_status("http://test")
+        assert status == 200


### PR DESCRIPTION
## Summary
- create `app` service for LangChain-based streaming chat API
- implement validation, decorators, and class hierarchy for chatbots
- add Dockerfile and requirements for gunicorn deployment
- include unit tests for schema validation and chat streaming
- support httpx-based helpers and update tests

## Testing
- `ruff check app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68899b2552ec8332bb97e528476e4e71