### PR TITLE
Split CI and CD pipelines

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,24 +1,18 @@
-name: Full CI/CD Pipeline
+name: Continuous Deployment
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 env:
   AWS_REGION: ca-central-1
   ECR_REPO: spark-etl
   IMAGE_TAG: latest
 
-
 jobs:
-  # ──────────────────────────────────────────────
-  # Build / Lint / Test / Push Docker Image
-  # ──────────────────────────────────────────────
-  build:
+  build-and-push:
     name: Build & Push Spark Image
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -38,19 +32,6 @@ jobs:
         run: |
           pip install -r data-pipeline/requirements.txt
 
-      - name: Lint with Ruff
-        run: ruff check .
-
-      - name: Run tests
-        run: |
-          pytest --junitxml=pytest-results.xml
-
-      - name: Upload test report
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-results
-          path: pytest-results.xml
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -60,9 +41,8 @@ jobs:
 
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v1
-        with :
+        with:
           mask-password: true
-
 
       - name: Build and Push Docker image
         run: |
@@ -73,13 +53,11 @@ jobs:
             --push \
             data-pipeline
 
-  # ──────────────────────────────────────────────
-  # Sync Airflow DAGs to MWAA S3 Bucket
-  # ──────────────────────────────────────────────
   deploy-dags:
     name: Deploy DAGs to MWAA
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-and-push
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
 
@@ -95,14 +73,11 @@ jobs:
           aws s3 sync data-pipeline/dags s3://${{ secrets.MWAA_DAGS_BUCKET }}/dags \
             --delete
 
-
-  # ──────────────────────────────────────────────
-  # Deploy Spark ETL Job to EKS
-  # ──────────────────────────────────────────────
   deploy-etl:
     name: Deploy Spark ETL to EKS
     runs-on: ubuntu-latest
     needs: deploy-dags
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
 
@@ -129,4 +104,3 @@ jobs:
           export ECR_URI=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO }}:${{ env.IMAGE_TAG }}
           envsubst < data-pipeline/k8s/spark-job.yaml | kubectl apply --validate=false -f -
           kubectl rollout status job/spark-etl
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,50 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  AWS_REGION: ca-central-1
+
+jobs:
+  ci:
+    name: Lint, Test & Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('data-pipeline/requirements.txt') }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install -r data-pipeline/requirements.txt
+
+      - name: Lint with Ruff
+        run: ruff check .
+
+      - name: Run tests
+        run: |
+          pytest --junitxml=pytest-results.xml
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: pytest-results.xml
+
+      - name: Build Docker image
+        run: |
+          docker build -t ci-test-image -f data-pipeline/docker/Dockerfile data-pipeline


### PR DESCRIPTION
## Summary
- split CI and CD GitHub workflows
- keep CI running for PRs and pushes to `main`
- make CD pipeline manual via `workflow_dispatch`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889a049fb188332b081dddb419710a2