### PR TITLE
Switch backend from Flask to Quart

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,11 @@
-from flask import Flask
+from quart import Quart
 
 from .routes import chat_bp
 from .services.chatbot import OpenAIChatBot
 
 
-def create_app(chatbot: OpenAIChatBot | None = None) -> Flask:
-    app = Flask(__name__)
+def create_app(chatbot: OpenAIChatBot | None = None) -> Quart:
+    app = Quart(__name__)
     if chatbot is None:
         chatbot = OpenAIChatBot()
     app.config["CHATBOT"] = chatbot

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from flask import request, jsonify
+from quart import jsonify, request
 
 
 def validate(model):
@@ -9,7 +9,7 @@ def validate(model):
         @wraps(func)
         async def wrapper(*args, **kwargs):
             try:
-                data = model(**request.get_json(force=True))
+                data = model(**(await request.get_json(force=True)))
             except Exception as exc:  # pragma: no cover - simple example
                 return jsonify({"error": str(exc)}), 400
             return await func(data, *args, **kwargs)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,5 @@
-flask>=2.3
+quart>=0.19
+uvicorn>=0.29
 httpx>=0.25
 langchain>=0.1
 langchain-community>=0.0.21

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, Response, current_app
+from quart import Blueprint, Response, current_app
 
 from .decorators import log_call, validate
 from .schema import ChatInput

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -1,0 +1,15 @@
+import pytest
+
+from app import create_app
+from app.services.chatbot import DummyChatBot
+
+
+@pytest.mark.asyncio
+async def test_chat_endpoint(tmp_path):
+    bot = DummyChatBot()
+    app = create_app(chatbot=bot)
+    async with app.test_client() as client:
+        resp = await client.post("/chat", json={"message": "hello world"})
+        text = await resp.get_data(as_text=True)
+        assert resp.status_code == 200
+        assert text == "helloworld"


### PR DESCRIPTION
## Summary
- migrate backend from Flask to Quart
- adjust decorators and routes to use Quart request/response
- update dependencies for Quart and Uvicorn
- add test to cover `/chat` endpoint using Quart test client

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889b208111c833281792264f5554325