### PR TITLE
Enable local Airflow testing with docker compose

### DIFF
--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -1,0 +1,17 @@
+# Local Airflow Testing
+
+This repository provides a simple Docker Compose setup for running the Airflow DAG locally.
+
+## Prerequisites
+- Docker and Docker Compose v1.29+
+
+## Quick start
+```bash
+# Build the Spark image used by the DAG
+docker compose build spark
+
+# Start Airflow (web UI available on http://localhost:8080)
+docker compose up airflow
+```
+
+The DAG `etl_csv_to_parquet_k8s` will run the Spark job using `DockerOperator` when the `LOCAL_AIRFLOW` environment variable is set (configured in `docker-compose.yaml`).

--- a/data-pipeline/dags/etl_job.py
+++ b/data-pipeline/dags/etl_job.py
@@ -1,7 +1,10 @@
 from airflow import DAG
+import os
+
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
     KubernetesPodOperator,
 )
+from airflow.providers.docker.operators.docker import DockerOperator
 from datetime import datetime
 
 default_args = {
@@ -14,16 +17,27 @@ with DAG(
     schedule_interval=None,
     catchup=False,
     default_args=default_args,
-    description="Run PySpark ETL in KubernetesPodOperator",
+    description="Run PySpark ETL",
 ) as dag:
-    run_spark = KubernetesPodOperator(
-        task_id="run_spark_job",
-        name="spark-etl-job",
-        namespace="default",
-        image="271111372751.dkr.ecr.ca-central-1.amazonaws.com/spark-etl:latest",
-        cmds=["/opt/bitnami/spark/bin/spark-submit"],
-        arguments=["/app/etl_job.py"],
-        get_logs=True,
-        is_delete_operator_pod=True,
-        service_account_name="spark-runner",
-    )
+    if os.getenv("LOCAL_AIRFLOW", "false").lower() == "true":
+        run_spark = DockerOperator(
+            task_id="run_spark_job",
+            image="spark-etl:local",
+            auto_remove=True,
+            command="/opt/bitnami/spark/bin/spark-submit /app/etl_job.py",
+            docker_url="unix://var/run/docker.sock",
+            network_mode="bridge",
+        )
+    else:
+        run_spark = KubernetesPodOperator(
+            task_id="run_spark_job",
+            name="spark-etl-job",
+            namespace="default",
+            image="271111372751.dkr.ecr.ca-central-1.amazonaws.com/spark-etl:latest",
+            cmds=["/opt/bitnami/spark/bin/spark-submit"],
+            arguments=["/app/etl_job.py"],
+            get_logs=True,
+            is_delete_operator_pod=True,
+            service_account_name="spark-runner",
+        )
+

--- a/data-pipeline/docker/Dockerfile
+++ b/data-pipeline/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN pip install pandas boto3 pyarrow s3fs
 ENV PYSPARK_PYTHON=python3
 ENV PYSPARK_DRIVER_PYTHON=python3
 
-COPY dags/etl_job.py /app/etl_job.py
+COPY spark_jobs/etl_csv_to_parquet_k8s.py /app/etl_job.py
 WORKDIR /app
 
 ENTRYPOINT ["spark-submit", "etl_job.py"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,21 @@
+version: "3.8"
+
+services:
+  spark:
+    build:
+      context: ./data-pipeline
+      dockerfile: docker/Dockerfile
+    image: spark-etl:local
+
+  airflow:
+    image: apache/airflow:2.7.2
+    environment:
+      AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+      LOCAL_AIRFLOW: "true"
+    volumes:
+      - ./data-pipeline/dags:/opt/airflow/dags
+      - ./data-pipeline/spark_jobs:/opt/airflow/spark_jobs
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "8080:8080"
+    command: airflow standalone


### PR DESCRIPTION
## Summary
- allow running the DAG with DockerOperator when LOCAL_AIRFLOW=true
- build Spark container for local tests
- provide `docker-compose.yaml` with Airflow and Spark services
- document how to run the pipeline locally
- remove incompatible LocalExecutor setting

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889999c3bc08332820b7ecb10ccf3fc