### PR TITLE
Add Postgres for Airflow LocalExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The `data-pipeline` service includes a DAG to run a PySpark job either inside Do
 # Build the Spark image used by the DAG
 docker compose build spark
 
-# Start Airflow (web UI on http://localhost:8080)
-docker compose up airflow
+# Start Postgres and Airflow (web UI on http://localhost:8080)
+docker compose up postgres airflow
 ```
 
 The DAG `etl_csv_to_parquet_k8s` will run the Spark job using `DockerOperator` when the `LOCAL_AIRFLOW` environment variable is set.

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -10,8 +10,8 @@ This repository provides a simple Docker Compose setup for running the Airflow D
 # Build the Spark image used by the DAG
 docker compose build spark
 
-# Start Airflow (web UI available on http://localhost:8080)
-docker compose up airflow
+# Start Postgres and Airflow (web UI available on http://localhost:8080)
+docker compose up postgres airflow
 ```
 
 The DAG `etl_csv_to_parquet_k8s` will run the Spark job using `DockerOperator` when the `LOCAL_AIRFLOW` environment variable is set (configured in `docker-compose.yaml`).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,16 +7,38 @@ services:
       dockerfile: docker/Dockerfile
     image: spark-etl:local
 
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U airflow"]
+      interval: 5s
+      retries: 5
+    volumes:
+      - postgres-db-volume:/var/lib/postgresql/data
+
   airflow:
     image: apache/airflow:2.7.2
     environment:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
+      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
       AIRFLOW__CORE__LOAD_EXAMPLES: "false"
       LOCAL_AIRFLOW: "true"
     volumes:
       - ./data-pipeline/dags:/opt/airflow/dags
       - ./data-pipeline/spark_jobs:/opt/airflow/spark_jobs
       - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      postgres:
+        condition: service_healthy
     ports:
       - "8080:8080"
     command: airflow standalone
+
+volumes:
+  postgres-db-volume:


### PR DESCRIPTION
## Summary
- add a Postgres service to `docker-compose.yaml`
- configure Airflow to use Postgres
- document new startup instructions in READMEs

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889d23e90ec83329d9522c61329590b