### PR TITLE
refactor: modularize chat components

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,125 +1,114 @@
-import { useEffect, useRef, useState } from 'react'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
-import remarkBreaks from 'remark-breaks'
-import rehypeHighlight from 'rehype-highlight'
-import 'highlight.js/styles/github-dark-dimmed.css'
-import './App.css'
+import { useCallback, useEffect, useRef, useState } from "react";
+import "./App.css";
+import MessageList from "./components/MessageList";
+import MessageInput from "./components/MessageInput";
 
 function isAbortError(err: unknown): boolean {
   return (
-    typeof err === 'object' &&
+    typeof err === "object" &&
     err !== null &&
-    'name' in err &&
-    (err as { name?: string }).name === 'AbortError'
-  )
+    "name" in err &&
+    (err as { name?: string }).name === "AbortError"
+  );
 }
 
 function App() {
-  const [input, setInput] = useState('')
-  const [messages, setMessages] = useState<{ role: 'user' | 'assistant'; content: string }[]>(() => {
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<
+    { role: "user" | "assistant"; content: string }[]
+  >(() => {
     try {
-      const raw = localStorage.getItem('chat_messages')
-      return raw ? (JSON.parse(raw) as { role: 'user' | 'assistant'; content: string }[]) : []
+      const raw = localStorage.getItem("chat_messages");
+      return raw
+        ? (JSON.parse(raw) as { role: "user" | "assistant"; content: string }[])
+        : [];
     } catch {
-      return []
+      return [];
     }
-  })
-  const [loading, setLoading] = useState(false)
-  const [theme, setTheme] = useState<'dark' | 'light'>(() => (localStorage.getItem('theme') as 'dark' | 'light') || 'dark')
-  const [controller, setController] = useState<AbortController | null>(null)
-  const endRef = useRef<HTMLDivElement | null>(null)
+  });
+  const [loading, setLoading] = useState(false);
+  const [theme, setTheme] = useState<"dark" | "light">(
+    () => (localStorage.getItem("theme") as "dark" | "light") || "dark",
+  );
+  const [controller, setController] = useState<AbortController | null>(null);
+  const endRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    endRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
 
   useEffect(() => {
-    const root = document.documentElement
-    if (theme === 'dark') root.classList.add('dark')
-    else root.classList.remove('dark')
-    localStorage.setItem('theme', theme)
-  }, [theme])
+    const root = document.documentElement;
+    if (theme === "dark") root.classList.add("dark");
+    else root.classList.remove("dark");
+    localStorage.setItem("theme", theme);
+  }, [theme]);
 
   useEffect(() => {
     try {
-      localStorage.setItem('chat_messages', JSON.stringify(messages))
+      localStorage.setItem("chat_messages", JSON.stringify(messages));
     } catch {
       /* ignore */
     }
-  }, [messages])
+  }, [messages]);
 
-  async function send() {
-    if (!input.trim() || loading) return
-    const text = input
-    setInput('')
-    setMessages((m) => [...m, { role: 'user', content: text }])
-    setLoading(true)
+  const send = useCallback(async () => {
+    if (!input.trim() || loading) return;
+    const text = input;
+    setInput("");
+    setMessages((m) => [...m, { role: "user", content: text }]);
+    setLoading(true);
 
-    const aborter = new AbortController()
-    setController(aborter)
+    const aborter = new AbortController();
+    setController(aborter);
 
     try {
-      const resp = await fetch('/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const resp = await fetch("/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: text }),
         signal: aborter.signal,
-      })
-      const reader = resp.body?.getReader()
-      const decoder = new TextDecoder()
-      let assistant = ''
+      });
+      const reader = resp.body?.getReader();
+      const decoder = new TextDecoder();
+      let assistant = "";
       if (reader) {
         while (true) {
-          const { value, done } = await reader.read()
-          if (done) break
-          assistant += decoder.decode(value, { stream: true })
+          const { value, done } = await reader.read();
+          if (done) break;
+          assistant += decoder.decode(value, { stream: true });
           setMessages((m) => {
-            const base = m
-            const lastIsAssistant = base[base.length - 1]?.role === 'assistant'
+            const base = m;
+            const lastIsAssistant = base[base.length - 1]?.role === "assistant";
             if (lastIsAssistant) {
-              const copy = [...base]
-              copy[copy.length - 1] = { role: 'assistant', content: assistant }
-              return copy
+              const copy = [...base];
+              copy[copy.length - 1] = { role: "assistant", content: assistant };
+              return copy;
             }
-            return [...base, { role: 'assistant', content: assistant }]
-          })
+            return [...base, { role: "assistant", content: assistant }];
+          });
         }
       }
     } catch (e: unknown) {
       if (!isAbortError(e)) {
-        setMessages((m) => [...m, { role: 'assistant', content: 'Error contacting server.' }])
+        setMessages((m) => [
+          ...m,
+          { role: "assistant", content: "Error contacting server." },
+        ]);
       }
     } finally {
-      setLoading(false)
-      setController(null)
+      setLoading(false);
+      setController(null);
     }
-  }
+  }, [input, loading]);
 
-  function stop() {
-    controller?.abort()
-  }
+  const stop = useCallback(() => {
+    controller?.abort();
+  }, [controller]);
 
-  function CodeBlock({ inline, className = '', children }: { inline?: boolean; className?: string; children?: React.ReactNode }) {
-    const code = String(children ?? '')
-    return inline ? (
-      <code className={className}>{children}</code>
-    ) : (
-      <div className="code-block">
-        <button
-          type="button"
-          className="copy-btn"
-          onClick={() => navigator.clipboard.writeText(code)}
-          aria-label="Copy code"
-        >
-          Copy
-        </button>
-        <pre className={className}>
-          <code>{code}</code>
-        </pre>
-      </div>
-    )
-  }
+  const toggleTheme = useCallback(() => {
+    setTheme((t) => (t === "dark" ? "light" : "dark"));
+  }, []);
 
   return (
     <div className="min-h-dvh bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100 flex flex-col">
@@ -127,17 +116,22 @@ function App() {
         <div className="mx-auto w-full max-w-3xl flex items-center justify-between">
           <h1 className="text-lg font-semibold tracking-tight">GenAI Chat</h1>
           <div className="flex items-center gap-2">
-            {loading && <span className="text-xs text-slate-500">Generating…</span>}
+            {loading && (
+              <span className="text-xs text-slate-500">Generating…</span>
+            )}
             {loading ? (
-              <button className="rounded-md border px-2 py-1 text-sm border-red-600 text-red-600" onClick={stop}>
+              <button
+                className="rounded-md border px-2 py-1 text-sm border-red-600 text-red-600"
+                onClick={stop}
+              >
                 Stop
               </button>
             ) : null}
             <button
               className="rounded-md border px-2 py-1 text-sm border-slate-300 dark:border-slate-700"
-              onClick={() => setTheme((t) => (t === 'dark' ? 'light' : 'dark'))}
+              onClick={toggleTheme}
             >
-              {theme === 'dark' ? 'Light' : 'Dark'} mode
+              {theme === "dark" ? "Light" : "Dark"} mode
             </button>
           </div>
         </div>
@@ -145,63 +139,22 @@ function App() {
 
       <main className="flex-1">
         <div className="mx-auto w-full max-w-3xl h-full flex flex-col">
-          <div className="flex-1 overflow-y-auto px-4 py-6 space-y-3">
-            {messages.map((m, i) => (
-              <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
-                {m.role === 'user' ? (
-                  <span className="inline-block rounded-2xl px-3 py-2 max-w-[80%] break-words shadow-sm bg-brand-600 text-white">
-                    {m.content}
-                  </span>
-                ) : (
-                  <div className="inline-block rounded-2xl px-3 py-2 max-w-[80%] break-words shadow-sm bg-slate-100 text-slate-900 ring-1 ring-slate-200 dark:bg-slate-800/80 dark:text-slate-100 dark:ring-slate-800 prose prose-slate dark:prose-invert prose-sm prose-pre:bg-slate-900 prose-pre:text-slate-100">
-                    <ReactMarkdown
-                      remarkPlugins={[remarkGfm, remarkBreaks]}
-                      rehypePlugins={[rehypeHighlight]}
-                      components={{ code: CodeBlock }}
-                    >
-                      {m.content}
-                    </ReactMarkdown>
-                  </div>
-                )}
-              </div>
-            ))}
-            <div ref={endRef} />
-          </div>
+          <MessageList messages={messages} endRef={endRef} />
         </div>
       </main>
 
       <footer className="sticky bottom-0 border-t border-slate-200 dark:border-slate-800 px-4 py-3 bg-white/80 dark:bg-slate-950/80 backdrop-blur">
         <div className="mx-auto w-full max-w-3xl flex gap-2 items-end">
-          <textarea
-            className="flex-1 rounded-md bg-white border border-slate-300 px-3 py-2 outline-none focus:ring-2 focus:ring-brand-500 placeholder:text-slate-500 dark:bg-slate-900 dark:border-slate-800 resize-none"
-            value={input}
-            rows={1}
-            onInput={(e) => {
-              const el = e.currentTarget
-              el.style.height = 'auto'
-              el.style.height = `${Math.min(el.scrollHeight, 200)}px`
-            }}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault()
-                send()
-              }
-            }}
-            placeholder="Type your message..."
-            disabled={loading}
+          <MessageInput
+            input={input}
+            setInput={setInput}
+            send={send}
+            loading={loading}
           />
-          <button
-            className="rounded-md bg-brand-600 hover:bg-brand-500 disabled:opacity-50 px-4 py-2 text-white"
-            onClick={send}
-            disabled={loading || !input.trim()}
-          >
-            Send
-          </button>
         </div>
       </footer>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/ui/src/__tests__/MessageInput.test.tsx
+++ b/ui/src/__tests__/MessageInput.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import MessageInput from "../components/MessageInput";
+
+describe("MessageInput", () => {
+  it("calls send on Enter", async () => {
+    const send = vi.fn();
+    const setInput = vi.fn();
+    render(
+      <MessageInput
+        input="Hello"
+        setInput={setInput}
+        send={send}
+        loading={false}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText("Type your message...");
+    await userEvent.type(textarea, "{enter}");
+    expect(send).toHaveBeenCalled();
+  });
+});

--- a/ui/src/__tests__/MessageList.test.tsx
+++ b/ui/src/__tests__/MessageList.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import MessageList from "../components/MessageList";
+
+describe("MessageList", () => {
+  it("renders messages", () => {
+    const messages = [
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "Hello" },
+    ];
+    const endRef = { current: null };
+    render(<MessageList messages={messages} endRef={endRef} />);
+    expect(screen.getByText("Hi")).toBeInTheDocument();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/CodeBlock.tsx
+++ b/ui/src/components/CodeBlock.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+export default function CodeBlock({
+  inline,
+  className = "",
+  children,
+}: {
+  inline?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+}) {
+  const code = String(children ?? "");
+  return inline ? (
+    <code className={className}>{children}</code>
+  ) : (
+    <div className="code-block">
+      <button
+        type="button"
+        className="copy-btn"
+        onClick={() => navigator.clipboard.writeText(code)}
+        aria-label="Copy code"
+      >
+        Copy
+      </button>
+      <pre className={className}>
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/ui/src/components/MessageInput.tsx
+++ b/ui/src/components/MessageInput.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+interface MessageInputProps {
+  input: string;
+  setInput: (value: string) => void;
+  send: () => void;
+  loading: boolean;
+}
+
+export default function MessageInput({
+  input,
+  setInput,
+  send,
+  loading,
+}: MessageInputProps) {
+  return (
+    <>
+      <textarea
+        className="flex-1 rounded-md bg-white border border-slate-300 px-3 py-2 outline-none focus:ring-2 focus:ring-brand-500 placeholder:text-slate-500 dark:bg-slate-900 dark:border-slate-800 resize-none"
+        value={input}
+        rows={1}
+        onInput={(e) => {
+          const el = e.currentTarget;
+          el.style.height = "auto";
+          el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+        }}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            send();
+          }
+        }}
+        placeholder="Type your message..."
+        disabled={loading}
+      />
+      <button
+        className="rounded-md bg-brand-600 hover:bg-brand-500 disabled:opacity-50 px-4 py-2 text-white"
+        onClick={send}
+        disabled={loading || !input.trim()}
+      >
+        Send
+      </button>
+    </>
+  );
+}

--- a/ui/src/components/MessageList.tsx
+++ b/ui/src/components/MessageList.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
+import rehypeHighlight from "rehype-highlight";
+import "highlight.js/styles/github-dark-dimmed.css";
+import CodeBlock from "./CodeBlock";
+
+interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export default function MessageList({
+  messages,
+  endRef,
+}: {
+  messages: Message[];
+  endRef: React.RefObject<HTMLDivElement>;
+}) {
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-6 space-y-3">
+      {messages.map((m, i) => (
+        <div key={i} className={m.role === "user" ? "text-right" : "text-left"}>
+          {m.role === "user" ? (
+            <span className="inline-block rounded-2xl px-3 py-2 max-w-[80%] break-words shadow-sm bg-brand-600 text-white">
+              {m.content}
+            </span>
+          ) : (
+            <div className="inline-block rounded-2xl px-3 py-2 max-w-[80%] break-words shadow-sm bg-slate-100 text-slate-900 ring-1 ring-slate-200 dark:bg-slate-800/80 dark:text-slate-100 dark:ring-slate-800 prose prose-slate dark:prose-invert prose-sm prose-pre:bg-slate-900 prose-pre:text-slate-100">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm, remarkBreaks]}
+                rehypePlugins={[rehypeHighlight]}
+                components={{ code: CodeBlock }}
+              >
+                {m.content}
+              </ReactMarkdown>
+            </div>
+          )}
+        </div>
+      ))}
+      <div ref={endRef} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extract CodeBlock, MessageList, and MessageInput into standalone components
- memoize chat handlers with `useCallback` to avoid unnecessary renders
- add unit tests for new components

## Testing
- `npm test`
- `ruff format .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d4b79300c8332888ad163bc5eca3b