### PR TITLE
Fix frontend test backend URL handling

### DIFF
--- a/ui/src/__tests__/App.test.tsx
+++ b/ui/src/__tests__/App.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 
 // Provide a backend URL for tests before importing the app
-process.env.VITE_BACKEND_URL = 'http://example.com'
+vi.stubGlobal('__APP_BACKEND_URL', 'http://example.com')
 const App = (await import('../App')).default
 
 const cancel = vi.fn()


### PR DESCRIPTION
## Summary
- allow overriding backend base URL via global `__APP_BACKEND_URL`
- update App tests to stub the global backend URL

## Testing
- `ruff format .`
- `ruff check .`
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8c2ff6bb0833289c5ea682a5f8826