### PR TITLE
Add Makefile and cross-reference contributor guides

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,7 @@
 # Generative AI System
 
+These instructions are for generative AI agents contributing to this repository. Human developers should refer to [README.md](../README.md) for project overview. Always review [README.md](../README.md) and [AGENTS.md](../AGENTS.md) for up-to-date guidance before making changes.
+
 This repository contains a data pipeline service, a backend service, a frontend UI, and infrastructure code. The backend service provides a Quart web application using Blueprints, asyncio, httpx, Gunicorn, and LangChain for streaming chatbots. The frontend is a Vite + React + TypeScript app that consumes the streaming chat endpoint.
 
 Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
-# Guidelines for Generative AI Developers
+# Guidelines for Generative AI Contributors
 
-This repository contains a data pipeline service, a backend service, and infrastructure code. The backend service provides a Quart web application using Blueprints, asyncio, httpx, Gunicorn, and LangChain for streaming chatbots.
+This document is for generative AI agents working in this repository. Human developers should read [README.md](README.md) for project guidance.
 
 Follow the rules in this document when creating or modifying code anywhere in the repository.
+
+Always check [README.md](README.md) and [.github/copilot-instructions.md](.github/copilot-instructions.md) for updated guidance before starting work.
 
 ## General Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: help app ui airflow down lint test
+
+help: ## Display available targets
+	@grep -E '^[a-zA-Z_-]+:.*##' Makefile | awk 'BEGIN {FS = ":.*##"}; {printf "%-20s %s\n", $$1, $$2}'
+
+app: ## Build and run only the backend app service
+	docker compose up --build -d app
+
+ui: ## Build and run the backend and UI services
+	docker compose up --build -d app ui
+
+airflow: ## Build Spark image and start the full Airflow stack
+	docker compose build spark
+	docker compose up airflow-init
+	docker compose up
+
+down: ## Stop and remove all services
+	docker compose down
+
+lint: ## Format and lint Python and UI code
+	ruff format .
+	ruff check .
+	cd ui && npm run lint && npm run format
+
+test: ## Run backend and frontend test suites
+	pytest
+	cd ui && npm run test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a comprehensive data pipeline service, backend service, and infrastructure code designed for scalable generative AI workloads. The backend service provides a Quart web application using Blueprints, asyncio, httpx, Gunicorn, and LangChain for streaming chatbots.
 
+This README is intended for human contributors. Generative AI agents should consult [AGENTS.md](AGENTS.md) and [.github/copilot-instructions.md](.github/copilot-instructions.md) for workflow details before making changes.
+
 ## Architecture Overview
 
 - **data-pipeline/** – Airflow DAGs and PySpark jobs running on Kubernetes
@@ -158,12 +160,27 @@ docker compose up -d app ui
 # Backend: http://localhost:8000
 ```
 
+### Makefile commands
+Common development tasks are available through the `Makefile`:
+
+```bash
+make app      # docker compose up --build -d app
+make ui       # docker compose up --build -d app ui
+make airflow  # build Spark image and start full Airflow stack
+make down     # docker compose down
+make lint     # format and lint Python and UI code
+make test     # run backend and frontend tests
+```
+
+Run `make help` to list all available targets.
+
 ## Testing and Quality Assurance
+
+Use `make lint` to format and lint Python and UI code, and `make test` to run backend and frontend tests.
 
 ### Running Tests
 ```bash
-# Run complete test suite
-pytest
+make test  # run complete test suite
 
 # Run with coverage
 pytest --cov=app --cov=data-pipeline
@@ -171,6 +188,8 @@ pytest --cov=app --cov=data-pipeline
 
 ### Code Quality
 ```bash
+make lint  # format and lint Python and UI code
+
 # Format code
 ruff format .
 
@@ -179,12 +198,6 @@ ruff check .
 
 # Fix auto-fixable issues
 ruff check . --fix
-```
-
-### UI
-```bash
-cd ui
-npm run lint && npm run format && npm run test
 ```
 
 ## Deployment
@@ -271,4 +284,4 @@ curl http://localhost:8000/health
 5. Update documentation for any new features
 6. Submit pull requests for review
 
-For more detailed information about individual components, refer to the README files in each service directory.
+Always verify that [AGENTS.md](AGENTS.md) and [.github/copilot-instructions.md](.github/copilot-instructions.md) are up to date, especially if you are a generative AI agent. For more detailed information about individual components, refer to the README files in each service directory.


### PR DESCRIPTION
## Summary
- ensure `lint` target formats and lints Python and UI code
- ensure `test` target runs backend and frontend suites
- clarify README for human developers and link to AGENTS and Copilot instructions
- revise AGENTS and Copilot instructions for generative AI agents and cross-reference README
- remove duplicate workflow Copilot instructions file

## Testing
- `pip install -r app/requirements.txt`
- `pip install -r data-pipeline/requirements.txt` *(fails: No such file or directory)*
- `cd ui && npm ci`
- `make lint`
- `make test` *(fails: Unable to find an element with the text Stop)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b348a20c83329989a52b45451e80